### PR TITLE
Add city and Country code on users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,10 +44,11 @@ gem 'sidekiq-scheduler'
 gem 'custom_error_message', git: 'https://github.com/thethanghn/custom-err-msg.git'
 gem 'rqrcode'
 
-
 # Logging
 gem 'lograge', '>= 0.11.2'
 
+# Geo coding
+gem 'geocoder'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
     fugit (1.1.6)
       et-orbi (~> 1.1, >= 1.1.6)
       raabro (~> 1.1)
+    geocoder (1.6.2)
     geokit (1.13.1)
     geokit-rails (2.3.1)
       geokit (~> 1.5)
@@ -387,6 +388,7 @@ DEPENDENCIES
   fcm
   figaro
   foreman
+  geocoder
   geokit-rails (>= 2.3.1)
   jbuilder (~> 2.5)
   letter_opener (~> 1.6)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
-
 class User < ApplicationRecord
+  include ExceptionHandlers
+
   acts_as_mappable
   audited except: :password
   devise :database_authenticatable, :registerable, :timeoutable, :lockable,
@@ -35,7 +36,7 @@ class User < ApplicationRecord
       user.country_code = geo.country_code
     end
   rescue => e
-    Rails.logger.error("Failed to geocode city or country_code due to #{e.message}")
+    report_exception(e)
   end
   after_validation :reverse_geocode
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,17 @@ class User < ApplicationRecord
   validate :lat_lng_unchanged
   validates_length_of :name, minimum: 3, maximum: 30
 
+  # Reverse geocoding for city finder
+  reverse_geocoded_by :lat, :lng do |user, results|
+    if geo = results.first
+      user.city = geo.city
+      user.country_code = geo.country_code
+    end
+  rescue => e
+    Rails.logger.error("Failed to geocode city or country_code due to #{e.message}")
+  end
+  after_validation :reverse_geocode
+
   before_create :set_identifier
 
   def set_identifier

--- a/db/migrate/20200328172444_add_city_on_users.rb
+++ b/db/migrate/20200328172444_add_city_on_users.rb
@@ -1,0 +1,5 @@
+class AddCityOnUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :city, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_28_074429) do
+ActiveRecord::Schema.define(version: 2020_03_28_172444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2020_03_28_074429) do
     t.string "identifier"
     t.decimal "lat", precision: 10, scale: 6
     t.decimal "lng", precision: 10, scale: 6
+    t.string "city"
     t.index ["auth_token"], name: "index_users_on_auth_token"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email"


### PR DESCRIPTION
closes: https://github.com/coronagoapp/coronago-backend/issues/10
## Why

We want to find out the country code and the city based on the lat, long pair.

## What

- Adds a new city column on the users table(no indexing yet, since we do not know the access patterns of this column)
- Adds [geocoder](https://github.com/alexreisner/geocoder) that provides reverse geocoding.

### Happy scenario
lat, lng: 51.509865, -0.118092 (expected behaviour, city: London, country_code: gb)

![Screenshot 2020-03-28 at 18 05 58](https://user-images.githubusercontent.com/214563/77830197-cb2e7b00-711e-11ea-86c9-bd09e7fc415e.png)


### Failure scenario
Raising an exception while geocoding. Expected behaviour: Fail-safe on error

![Screenshot 2020-03-28 at 18 06 54](https://user-images.githubusercontent.com/214563/77830218-ec8f6700-711e-11ea-91c2-88b3b9ca1259.png)

/cc @prasadpilla @arunava59 
