### PR TITLE
Remove identifier from user and wallet transaction

### DIFF
--- a/app/models/concerns/identifier_generators.rb
+++ b/app/models/concerns/identifier_generators.rb
@@ -1,9 +1,0 @@
-module IdentifierGenerators
-
-  def generate_hex_identifier(n)
-    loop do
-      identifier = SecureRandom.hex(n)
-      break identifier unless self.class.find_by(beneficiary_id: identifier).present?
-    end
-  end
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,19 +28,6 @@ class User < ApplicationRecord
   validate :lat_lng_unchanged
   validates_length_of :name, minimum: 3, maximum: 30
 
-  before_create :set_identifier
-
-  def set_identifier
-    self.identifier = generate_identifier
-  end
-
-  def generate_identifier
-    loop do
-      identifier = 8.times.map{rand(10)}.join
-      break identifier unless User.where(identifier: identifier).exists?
-    end
-  end
-
   def password_complexity
     return if password.blank? || password =~ /^(?=.*?[a-z])(?=.*?[#?!@$%^&*-]).{8,70}$/
     errors.add :password, :password_complexity_error

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -5,19 +5,4 @@ class WalletTransaction < ApplicationRecord
   belongs_to :charge_session, optional: true
 
   enum transaction_type: [:debit, :credit]
-
-  before_create :set_identifier
-
-  private
-
-  def set_identifier
-    self.identifier = generate_identifier
-  end
-
-  def generate_identifier
-    loop do
-      identifier = 8.times.map{rand(10)}.join
-      break identifier unless self.class.where(identifier: identifier).exists?
-    end
-  end
 end

--- a/app/serializers/wallet_transaction_serializer.rb
+++ b/app/serializers/wallet_transaction_serializer.rb
@@ -1,4 +1,4 @@
 class WalletTransactionSerializer < ActiveModel::Serializer
-  attributes :id, :identifier, :description, :amount, :transaction_type, :timestamp, :closing_balance
+  attributes :id, :description, :amount, :transaction_type, :timestamp, :closing_balance
 end
 

--- a/db/migrate/20200329155716_remove_identifiers_from_users_and_wallet_transactions.rb
+++ b/db/migrate/20200329155716_remove_identifiers_from_users_and_wallet_transactions.rb
@@ -1,0 +1,6 @@
+class RemoveIdentifiersFromUsersAndWalletTransactions < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :identifier
+    remove_column :wallet_transactions, :identifier
+  end
+end


### PR DESCRIPTION
Based on https://discordapp.com/channels/691926147029663805/691926279091650560/693554386408046632

This are left overs and safely can be removed